### PR TITLE
Fixing conversion error in ENgetnodevalue EN_TANKDIAM

### DIFF
--- a/src/epanet/src/epanet.c
+++ b/src/epanet/src/epanet.c
@@ -1476,7 +1476,7 @@ int DLLEXPORT ENgetnodevalue(int index, int code, double *value)
          v = 0.0;
          if ( index > Njuncs )
          {
-            v = 4.0/PI*sqrt(Tank[index-Njuncs].A)*Ucf[ELEV];
+            v = sqrt(4.0/PI*Tank[index-Njuncs].A)*Ucf[ELEV];
          }
          break;
 


### PR DESCRIPTION
Same in epanet-rtx

The Tank.A(area) is calculated as:
Tank[j].A = PI_SQR(Tank[j].A/Ucf[ELEV])/4.0; //diameter is stored in Tank[j].A
so the right equation to get the diameter back is sqrt(4.0/PI_Tank[index-Njuncs].A)*Ucf[ELEV];
